### PR TITLE
OPS-1289 - npm org name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
- - OPS-1289 change the name form the npm organisation
+ - OPS-1289 change the npm organisation namen
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog of commons
 
+## Unreleased
+
+### Changed
+ - OPS-1289 change the name form the npm organisation
+
 ## 1.3.0
 
 ### Changes in 1.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@schul-cloud/commons",
+	"name": "@hpi-schul-cloud/commons",
 	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-	"name": "@schul-cloud/commons",
+	"name": "@hpi-schul-cloud/commons",
 	"version": "1.3.0",
 	"description": "Helpers and common tools for the hpi school-cloud.",
 	"repository": {
-		"github": "https: //github.com/schul-cloud/commons"
+		"github": "https: //github.com/hpi-schul-cloud/commons"
 	},
 	"license": "MIT",
 	"main": "lib/index.js",
-	"homepage": "https://github.com/schul-cloud/commons",
+	"homepage": "https://github.com/hpi-schul-cloud/commons",
 	"scripts": {
 		"coverage": "cross-env NODE_ENV=test nyc mocha -r ts-node/register -r tsconfig-paths/register test/**/*.spec.ts",
 		"mocha": "NODE_ENV=test mocha -r ts-node/register -r tsconfig-paths/register test/**/*.spec.ts",


### PR DESCRIPTION
# Description
 - This pullrequest change the NPM Organisation name to hpi-schul-cloud
## Links to Tickets or other pull requests
 - https://ticketsystem.hpi-schul-cloud.org/browse/OPS-1289
## Changes
 - Name of the NPM Organisation

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
 - only name change to hpi-schul-cloud

## Deployment
 - with the next styl release
## New Repos, NPM pakages or vendor scripts
 - new NPM Organisation name
## Screenshots of UI changes
 - No UI changes

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
