### PR TITLE
fix dot notation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- fix dot notation handling in toObject and update
 - updated changelog github action
 
 ## 1.3.2

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -302,8 +302,13 @@ export class Configuration implements IConfiguration {
 	 */
 	toObject(options?: IExportOptions): IConfig {
 		this.ensureInitialized();
-		let config: IConfig = loadash.cloneDeep(this.configDottedExternal);
+		let config: IConfig;
 		const mergedOptions = loadash.merge({}, this.options, options);
+		if (mergedOptions.useDotNotation === false) {
+			config = loadash.cloneDeep(this.configObjectInternal);
+		} else {
+			config = loadash.cloneDeep(this.configDottedExternal);
+		}
 		if (mergedOptions.plainSecrets !== true) {
 			config = this.secretCleaner.filterSecretValues(config);
 		}
@@ -401,9 +406,9 @@ export class Configuration implements IConfiguration {
 		this.ensureInitialized();
 		this.restrictRuntimeChanges();
 		this.updateErrors = [];
-		const updatedParams = loadash.cloneDeep(params);
+		let updatedParams = loadash.cloneDeep(params);
 		if (this.dot !== null) {
-			this.dot.object(updatedParams);
+			updatedParams = this.dot.object(updatedParams);
 		}
 		let data = null;
 		if (options && options.reset === true) {

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -69,12 +69,9 @@ export class Configuration implements IConfiguration {
 	private static instance: Configuration;
 	private options: IRequiredConfigOptions;
 	private dot: DotObject.Dot | null;
-	private data: IConfig;
+	private configObjectInternal: IConfig;
 	private schema: any;
-	/**
-	 * keeps the current configuration as object
-	 */
-	private config: any;
+	private configDottedExternal: any;
 	private schemaValidator: Ajv.Ajv;
 	private validate?: Ajv.ValidateFunction;
 	private updateErrors: string[];
@@ -91,7 +88,7 @@ export class Configuration implements IConfiguration {
 	 * @deprecated use singleton getInstance() instead, this will be private in future versions
 	 */
 	constructor(options?: IConfigOptions) {
-		this.data = {};
+		this.configObjectInternal = {};
 		this.updateErrors = [];
 		this.readyState = ReadyState.InstanceCreated;
 		//
@@ -258,14 +255,14 @@ export class Configuration implements IConfiguration {
 
 	has = (key: string): boolean => {
 		this.ensureInitialized();
-		return Object.prototype.hasOwnProperty.call(this.config, key);
+		return Object.prototype.hasOwnProperty.call(this.configDottedExternal, key);
 	};
 
 	get = (key: string): any => {
 		this.ensureInitialized();
 		// first check config has key, then return it (duplication because of reduce config clone amount)
-		if (Object.prototype.hasOwnProperty.call(this.config, key)) {
-			const retValue = loadash.cloneDeep(this.config[key]);
+		if (Object.prototype.hasOwnProperty.call(this.configDottedExternal, key)) {
+			const retValue = loadash.cloneDeep(this.configDottedExternal[key]);
 			return retValue;
 		}
 		return this.notFound(key);
@@ -287,12 +284,12 @@ export class Configuration implements IConfiguration {
 	 * @type {*}
 	 * @memberof Configuration
 	 */
-	private updateConfig(): void {
+	private updateConfigDottedExternal(): void {
 		if (this.dot !== null) {
-			this.config = this.dot.dot(this.data);
+			this.configDottedExternal = this.dot.dot(this.configObjectInternal);
 			return;
 		} else {
-			this.config = loadash.cloneDeep(this.data);
+			this.configDottedExternal = loadash.cloneDeep(this.configObjectInternal);
 			return;
 		}
 	}
@@ -305,12 +302,7 @@ export class Configuration implements IConfiguration {
 	 */
 	toObject(options?: IExportOptions): IConfig {
 		this.ensureInitialized();
-		let config: IConfig;
-		if (this.dot !== null) {
-			config = loadash.cloneDeep(this.dot.object(this.config));
-		} else {
-			config = loadash.cloneDeep(this.config);
-		}
+		let config: IConfig = loadash.cloneDeep(this.configDottedExternal);
 		const mergedOptions = loadash.merge({}, this.options, options);
 		if (mergedOptions.plainSecrets !== true) {
 			config = this.secretCleaner.filterSecretValues(config);
@@ -417,7 +409,7 @@ export class Configuration implements IConfiguration {
 		if (options && options.reset === true) {
 			data = updatedParams;
 		} else {
-			data = loadash.merge({}, this.data, updatedParams);
+			data = loadash.merge({}, this.configObjectInternal, updatedParams);
 		}
 		return this.parse(data);
 	}
@@ -452,7 +444,7 @@ export class Configuration implements IConfiguration {
 		this.ensureInitialized();
 		this.restrictRuntimeChanges();
 		this.updateErrors = [];
-		const data = loadash.omit(this.config, keys);
+		const data = loadash.omit(this.configDottedExternal, keys);
 		if (this.dot !== null) {
 			this.dot.object(data);
 		}
@@ -477,8 +469,8 @@ export class Configuration implements IConfiguration {
 		const dataToBeUpdated = loadash.cloneDeep(data);
 		const valid = this.validate(dataToBeUpdated) as boolean;
 		if (valid) {
-			this.data = dataToBeUpdated;
-			this.updateConfig();
+			this.configObjectInternal = dataToBeUpdated;
+			this.updateConfigDottedExternal();
 		} else {
 			const message = 'error updating configuration data';
 			this.printHierarchy('error');

--- a/src/interfaces/IExportOptions.ts
+++ b/src/interfaces/IExportOptions.ts
@@ -1,4 +1,6 @@
 export interface IExportOptions {
 	/** enable or override to print secrets in printHierarchy or export them in toObject */
 	plainSecrets?: boolean;
+	/** enforce object style to be selected for export setting this false while useDotNotation is enabled  */
+	useDotNotation?: boolean;
 }

--- a/test/configuration/index.spec.ts
+++ b/test/configuration/index.spec.ts
@@ -241,6 +241,19 @@ describe('test configuration', () => {
 			expect(process.env[configPath]).to.be.undefined;
 		});
 
+		it('parse nested property from toObject', () => {
+			const configPath = 'TEST__NESTED__DOT_ENV_VALUE';
+			expect(process.env[configPath]).to.be.undefined;
+			const config = new Configuration(options);
+			const beforeReset = config.toObject();
+			config.reset(beforeReset);
+			const afterReset = config.toObject();
+			expect(
+				afterReset,
+				'config matches befor state after importing before state'
+			).to.deep.equal(beforeReset);
+		});
+
 		it('requesting nested values', () => {
 			process.env[configNestedFoo] = 'another bar';
 			const config = new Configuration(options);
@@ -268,11 +281,18 @@ describe('test configuration', () => {
 			const helloWorld = 'Hello World!';
 			ConfigurationSingleton.set('Foo__Bar', helloWorld);
 			expect(ConfigurationSingleton.get('Foo__Bar')).to.be.equal(helloWorld);
-			const currentConfig = ConfigurationSingleton.toObject();
-			expect(currentConfig.Foo).to.exist;
-			expect(currentConfig.Foo.Bar).to.exist;
-			expect(currentConfig.Foo.Bar).to.be.not.empty;
-			expect(currentConfig.Foo.Bar).to.be.equal(helloWorld);
+			// useDotNotation is true in ConfigurationSingleton
+			const currentDottedConfig = ConfigurationSingleton.toObject();
+			expect(currentDottedConfig['Foo__Bar']).to.exist;
+			expect(currentDottedConfig['Foo__Bar']).to.be.not.empty;
+			expect(currentDottedConfig['Foo__Bar']).to.be.equal(helloWorld);
+			// enforce object style against default
+			const currentObjectConfig = ConfigurationSingleton.toObject({
+				useDotNotation: false,
+			});
+			expect(currentObjectConfig.Foo.Bar).to.exist;
+			expect(currentObjectConfig.Foo.Bar).to.be.not.empty;
+			expect(currentObjectConfig.Foo.Bar).to.be.equal(helloWorld);
 		});
 	});
 


### PR DESCRIPTION
`update` and `toObject` missed some conversion to be correctly applied, which causes issues when using `toObject` and `reset` for child properties